### PR TITLE
Discard invalid transactions from blocks, but keep them in the batch

### DIFF
--- a/beacon/engine/gen_blockparams.go
+++ b/beacon/engine/gen_blockparams.go
@@ -22,6 +22,7 @@ func (p PayloadAttributes) MarshalJSON() ([]byte, error) {
 		Withdrawals           []*types.Withdrawal `json:"withdrawals,omitempty" gencodec:"optional"`
 		Transactions          []hexutil.Bytes     `json:"transactions,omitempty"  gencodec:"optional"`
 		NoTxPool              bool                `json:"noTxPool,omitempty" gencodec:"optional"`
+		Espresso              bool                `json:"espresso,omitempty" gencodec:"optional"`
 		GasLimit              *hexutil.Uint64     `json:"gasLimit,omitempty" gencodec:"optional"`
 	}
 	var enc PayloadAttributes
@@ -36,6 +37,7 @@ func (p PayloadAttributes) MarshalJSON() ([]byte, error) {
 		}
 	}
 	enc.NoTxPool = p.NoTxPool
+	enc.Espresso = p.Espresso
 	enc.GasLimit = (*hexutil.Uint64)(p.GasLimit)
 	return json.Marshal(&enc)
 }
@@ -49,6 +51,7 @@ func (p *PayloadAttributes) UnmarshalJSON(input []byte) error {
 		Withdrawals           []*types.Withdrawal `json:"withdrawals,omitempty" gencodec:"optional"`
 		Transactions          []hexutil.Bytes     `json:"transactions,omitempty"  gencodec:"optional"`
 		NoTxPool              *bool               `json:"noTxPool,omitempty" gencodec:"optional"`
+		Espresso              *bool               `json:"espresso,omitempty" gencodec:"optional"`
 		GasLimit              *hexutil.Uint64     `json:"gasLimit,omitempty" gencodec:"optional"`
 	}
 	var dec PayloadAttributes
@@ -78,6 +81,9 @@ func (p *PayloadAttributes) UnmarshalJSON(input []byte) error {
 	}
 	if dec.NoTxPool != nil {
 		p.NoTxPool = *dec.NoTxPool
+	}
+	if dec.Espresso != nil {
+		p.Espresso = *dec.Espresso
 	}
 	if dec.GasLimit != nil {
 		p.GasLimit = (*uint64)(dec.GasLimit)

--- a/beacon/engine/gen_ed.go
+++ b/beacon/engine/gen_ed.go
@@ -32,6 +32,7 @@ func (e ExecutableData) MarshalJSON() ([]byte, error) {
 		BlockHash     common.Hash         `json:"blockHash"     gencodec:"required"`
 		Transactions  []hexutil.Bytes     `json:"transactions"  gencodec:"required"`
 		Withdrawals   []*types.Withdrawal `json:"withdrawals"`
+		Rejected      []types.RejectedTransaction `json:"rejected" gencodec:"optional"`
 	}
 	var enc ExecutableData
 	enc.ParentHash = e.ParentHash
@@ -54,6 +55,7 @@ func (e ExecutableData) MarshalJSON() ([]byte, error) {
 		}
 	}
 	enc.Withdrawals = e.Withdrawals
+	enc.Rejected = e.Rejected
 	return json.Marshal(&enc)
 }
 
@@ -75,6 +77,7 @@ func (e *ExecutableData) UnmarshalJSON(input []byte) error {
 		BlockHash     *common.Hash        `json:"blockHash"     gencodec:"required"`
 		Transactions  []hexutil.Bytes     `json:"transactions"  gencodec:"required"`
 		Withdrawals   []*types.Withdrawal `json:"withdrawals"`
+		Rejected      []types.RejectedTransaction `json:"rejected" gencodec:"optional"`
 	}
 	var dec ExecutableData
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -141,6 +144,9 @@ func (e *ExecutableData) UnmarshalJSON(input []byte) error {
 	}
 	if dec.Withdrawals != nil {
 		e.Withdrawals = dec.Withdrawals
+	}
+	if dec.Rejected != nil {
+		e.Rejected = dec.Rejected
 	}
 	return nil
 }

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -57,21 +57,22 @@ type payloadAttributesMarshaling struct {
 
 // ExecutableData is the data necessary to execute an EL payload.
 type ExecutableData struct {
-	ParentHash    common.Hash         `json:"parentHash"    gencodec:"required"`
-	FeeRecipient  common.Address      `json:"feeRecipient"  gencodec:"required"`
-	StateRoot     common.Hash         `json:"stateRoot"     gencodec:"required"`
-	ReceiptsRoot  common.Hash         `json:"receiptsRoot"  gencodec:"required"`
-	LogsBloom     []byte              `json:"logsBloom"     gencodec:"required"`
-	Random        common.Hash         `json:"prevRandao"    gencodec:"required"`
-	Number        uint64              `json:"blockNumber"   gencodec:"required"`
-	GasLimit      uint64              `json:"gasLimit"      gencodec:"required"`
-	GasUsed       uint64              `json:"gasUsed"       gencodec:"required"`
-	Timestamp     uint64              `json:"timestamp"     gencodec:"required"`
-	ExtraData     []byte              `json:"extraData"     gencodec:"required"`
-	BaseFeePerGas *big.Int            `json:"baseFeePerGas" gencodec:"required"`
-	BlockHash     common.Hash         `json:"blockHash"     gencodec:"required"`
-	Transactions  [][]byte            `json:"transactions"  gencodec:"required"`
-	Withdrawals   []*types.Withdrawal `json:"withdrawals"`
+	ParentHash    common.Hash                 `json:"parentHash"    gencodec:"required"`
+	FeeRecipient  common.Address              `json:"feeRecipient"  gencodec:"required"`
+	StateRoot     common.Hash                 `json:"stateRoot"     gencodec:"required"`
+	ReceiptsRoot  common.Hash                 `json:"receiptsRoot"  gencodec:"required"`
+	LogsBloom     []byte                      `json:"logsBloom"     gencodec:"required"`
+	Random        common.Hash                 `json:"prevRandao"    gencodec:"required"`
+	Number        uint64                      `json:"blockNumber"   gencodec:"required"`
+	GasLimit      uint64                      `json:"gasLimit"      gencodec:"required"`
+	GasUsed       uint64                      `json:"gasUsed"       gencodec:"required"`
+	Timestamp     uint64                      `json:"timestamp"     gencodec:"required"`
+	ExtraData     []byte                      `json:"extraData"     gencodec:"required"`
+	BaseFeePerGas *big.Int                    `json:"baseFeePerGas" gencodec:"required"`
+	BlockHash     common.Hash                 `json:"blockHash"     gencodec:"required"`
+	Transactions  [][]byte                    `json:"transactions"  gencodec:"required"`
+	Withdrawals   []*types.Withdrawal         `json:"withdrawals"`
+	Rejected      []types.RejectedTransaction `json:"rejected" gencodec:"optional"`
 }
 
 // JSON type overrides for executableData.
@@ -211,7 +212,7 @@ func ExecutableDataToBlock(params ExecutableData) (*types.Block, error) {
 		MixDigest:       params.Random,
 		WithdrawalsHash: withdrawalsRoot,
 	}
-	block := types.NewBlockWithHeader(header).WithBody(txs, nil /* uncles */).WithWithdrawals(params.Withdrawals)
+	block := types.NewBlockWithHeader(header).WithBody(txs, nil /* uncles */).WithWithdrawals(params.Withdrawals).WithRejected(params.Rejected)
 	if block.Hash() != params.BlockHash {
 		return nil, fmt.Errorf("blockhash mismatch, want %x, got %x", params.BlockHash, block.Hash())
 	}
@@ -237,6 +238,7 @@ func BlockToExecutableData(block *types.Block, fees *big.Int) *ExecutionPayloadE
 		Random:        block.MixDigest(),
 		ExtraData:     block.Extra(),
 		Withdrawals:   block.Withdrawals(),
+		Rejected:      block.Rejected(),
 	}
 	return &ExecutionPayloadEnvelope{ExecutionPayload: data, BlockValue: fees}
 }

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -41,6 +41,9 @@ type PayloadAttributes struct {
 	// NoTxPool is a field for rollups: if true, the no transactions are taken out of the tx-pool,
 	// only transactions from the above Transactions list will be included.
 	NoTxPool bool `json:"noTxPool,omitempty" gencodec:"optional"`
+	// Espresso indicates whether Espresso mode is enabled. If so, invalid transactions will be
+	// silently rejected, instead of causing the whole block to fail.
+	Espresso bool `json:"espresso,omitempty" gencodec:"optional"`
 	// GasLimit is a field for rollups: if set, this sets the exact gas limit the block produced with.
 	GasLimit *uint64 `json:"gasLimit,omitempty" gencodec:"optional"`
 }

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -352,9 +352,9 @@ func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.
 
 // FinalizeAndAssemble implements consensus.Engine, setting the final state and
 // assembling the block.
-func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt, withdrawals []*types.Withdrawal) (*types.Block, error) {
+func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt, withdrawals []*types.Withdrawal, rejected []types.RejectedTransaction) (*types.Block, error) {
 	if !beacon.IsPoSHeader(header) {
-		return beacon.ethone.FinalizeAndAssemble(chain, header, state, txs, uncles, receipts, nil)
+		return beacon.ethone.FinalizeAndAssemble(chain, header, state, txs, uncles, receipts, nil, rejected)
 	}
 	shanghai := chain.Config().IsShanghai(header.Number, header.Time)
 	if shanghai {
@@ -374,7 +374,7 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 	header.Root = state.IntermediateRoot(true)
 
 	// Assemble and return the final block.
-	return types.NewBlockWithWithdrawals(header, txs, uncles, receipts, withdrawals, trie.NewStackTrie(nil)), nil
+	return types.NewBlockWithWithdrawals(header, txs, uncles, receipts, withdrawals, trie.NewStackTrie(nil)).WithRejected(rejected), nil
 }
 
 // Seal generates a new sealing request for the given input block and pushes

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -572,7 +572,7 @@ func (c *Clique) Finalize(chain consensus.ChainHeaderReader, header *types.Heade
 
 // FinalizeAndAssemble implements consensus.Engine, ensuring no uncles are set,
 // nor block rewards given, and returns the final block.
-func (c *Clique) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt, withdrawals []*types.Withdrawal) (*types.Block, error) {
+func (c *Clique) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt, withdrawals []*types.Withdrawal, rejected []types.RejectedTransaction) (*types.Block, error) {
 	if len(withdrawals) > 0 {
 		return nil, errors.New("clique does not support withdrawals")
 	}
@@ -583,7 +583,7 @@ func (c *Clique) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
 
 	// Assemble and return the final block for sealing.
-	return types.NewBlock(header, txs, nil, receipts, trie.NewStackTrie(nil)), nil
+	return types.NewBlock(header, txs, nil, receipts, trie.NewStackTrie(nil)).WithRejected(rejected), nil
 }
 
 // Authorize injects a private key into the consensus engine to mint new blocks

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -97,7 +97,7 @@ type Engine interface {
 	// Note: The block header and state database might be updated to reflect any
 	// consensus rules that happen at finalization (e.g. block rewards).
 	FinalizeAndAssemble(chain ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction,
-		uncles []*types.Header, receipts []*types.Receipt, withdrawals []*types.Withdrawal) (*types.Block, error)
+		uncles []*types.Header, receipts []*types.Receipt, withdrawals []*types.Withdrawal, rejected []types.RejectedTransaction) (*types.Block, error)
 
 	// Seal generates a new sealing request for the given input block and pushes
 	// the result into the given channel.

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -493,7 +493,7 @@ func (ethash *Ethash) Finalize(chain consensus.ChainHeaderReader, header *types.
 
 // FinalizeAndAssemble implements consensus.Engine, accumulating the block and
 // uncle rewards, setting the final state and assembling the block.
-func (ethash *Ethash) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt, withdrawals []*types.Withdrawal) (*types.Block, error) {
+func (ethash *Ethash) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt, withdrawals []*types.Withdrawal, rejected []types.RejectedTransaction) (*types.Block, error) {
 	if len(withdrawals) > 0 {
 		return nil, errors.New("ethash does not support withdrawals")
 	}
@@ -504,7 +504,7 @@ func (ethash *Ethash) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
 
 	// Header seems complete, assemble into a block and return
-	return types.NewBlock(header, txs, uncles, receipts, trie.NewStackTrie(nil)), nil
+	return types.NewBlock(header, txs, uncles, receipts, trie.NewStackTrie(nil)).WithRejected(rejected), nil
 }
 
 // SealHash returns the hash of a block prior to it being sealed.

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -315,7 +315,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 			gen(i, b)
 		}
 		if b.engine != nil {
-			block, err := b.engine.FinalizeAndAssemble(chainreader, b.header, statedb, b.txs, b.uncles, b.receipts, b.withdrawals)
+			block, err := b.engine.FinalizeAndAssemble(chainreader, b.header, statedb, b.txs, b.uncles, b.receipts, b.withdrawals, nil)
 			if err != nil {
 				panic(err)
 			}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -350,26 +350,61 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	snap := st.state.Snapshot()
 
 	result, err := st.innerTransitionDb()
-	// Failed deposits must still be included. Unless we cannot produce the block at all due to the gas limit.
-	// On deposit failure, we rewind any state changes from after the minting, and increment the nonce.
-	if err != nil && err != ErrGasLimitReached && st.msg.IsDepositTx {
-		st.state.RevertToSnapshot(snap)
-		// Even though we revert the state changes, always increment the nonce for the next deposit transaction
-		st.state.SetNonce(st.msg.From, st.state.GetNonce(st.msg.From)+1)
-		// Record deposits as using all their gas (matches the gas pool)
-		// System Transactions are special & are not recorded as using any gas (anywhere)
-		// Regolith changes this behaviour so the actual gas used is reported.
-		// In this case the tx is invalid so is recorded as using all gas.
-		gasUsed := st.msg.GasLimit
-		if st.msg.IsSystemTx && !st.evm.ChainConfig().IsRegolith(st.evm.Context.Time) {
-			gasUsed = 0
+	if err != nil {
+		// Failed deposits must still be included. Deposits always consume their entire gas limit
+		// even if they fail, so if the whole block has insufficient gas to process a deposit to
+		// process a required deposit, we fail.
+		if st.msg.IsDepositTx && err != ErrGasLimitReached {
+			// On deposit failure, we rewind any state changes from after the minting, and increment the nonce.
+			st.state.RevertToSnapshot(snap)
+			// Even though we revert the state changes, always increment the nonce for the next deposit transaction
+			st.state.SetNonce(st.msg.From, st.state.GetNonce(st.msg.From)+1)
+			// Record deposits as using all their gas (matches the gas pool)
+			// System Transactions are special & are not recorded as using any gas (anywhere)
+			// Regolith changes this behaviour so the actual gas used is reported.
+			// In this case the tx is invalid so is recorded as using all gas.
+			gasUsed := st.msg.GasLimit
+			if st.msg.IsSystemTx && !st.evm.ChainConfig().IsRegolith(st.evm.Context.Time) {
+				gasUsed = 0
+			}
+			result = &ExecutionResult{
+				UsedGas:    gasUsed,
+				Err:        fmt.Errorf("failed deposit: %w", err),
+				ReturnData: nil,
+			}
+			err = nil
+		// Transactions sequenced by the Espresso Sequencer must be included in the payload; the
+		// sequencer has no discretion to exclude invalid ones. Thus, we treat invalid Espresso
+		// transactions as noops rather than failing the whole block. Unlike failed deposits, these
+		// are true noops -- the caller does not even pay gas; instead, we rely on the cost of
+		// sequencing the transactions via the Espresso Sequencer to prevent spam. The only failure
+		// modes here are consensus errors, like invalid signatures or nonces, or insufficient
+		// balance to pay the intrinsic gas. These are all very cheap to check, so this is not an
+		// effective spam vector, and Espresso block builders are incentivized not to take up
+		// limited block space with noop transactions anyways.
+		// TODO currently, we allow invalid noop transactions unconditionally. To avoid breaking
+		// with upstream OP, we should check if we are building/executing an Espresso block (i.e.
+		// change this `else` to an `else if`). The information we need to check this exists: the
+		// L1 block info encoded in the calldata of the block's first transaction contains a non-nil
+		// `Justification` field if and only if this is an Espresso block. However this info is very
+		// hard to get at, because the data structure is defined in the op-node derivation pipeline,
+		// so we don't have the API to deserialize it at this lower level of abstraction.
+		} else {
+			// Revert changes to thes state.
+			st.state.RevertToSnapshot(snap)
+			// Put the gas back in the gas pool which was taken out of the gas pool to purchase gas
+			// for this transaction. This could be non-zero if the transaction passed the signature
+			// and nonce check and successfully purchased gas, but then failed for some later
+			// reason, like its gas limit being too low for its intrinsic gas or the caller not
+			// having enough ETH for the amount of the transaction.
+			st.gp.AddGas(st.initialGas)
+			result = &ExecutionResult{
+				UsedGas:    0,
+				Err:        fmt.Errorf("detected invalid Espresso tx after purchasing %d gas, using %d gas: %w", st.initialGas, st.gasUsed(), err),
+				ReturnData: nil,
+			}
+			err = nil
 		}
-		result = &ExecutionResult{
-			UsedGas:    gasUsed,
-			Err:        fmt.Errorf("failed deposit: %w", err),
-			ReturnData: nil,
-		}
-		err = nil
 	}
 	return result, err
 }

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -217,7 +217,7 @@ type RejectedTransaction struct {
 	// blobs that were forced into the sequence by end users as rejected transactions.
 	Data []byte
 	// The position in the block at which this tranaction would have appeared had it been valid.
-	Pos int
+	Pos uint64
 }
 
 // "external" block encoding. used for eth protocol, etc.

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -178,6 +178,30 @@ type Block struct {
 	transactions Transactions
 	withdrawals  Withdrawals
 
+	// `rejected` is an OP/Espresso extension. It collects transactions which were included by the
+	// OP sequencer in the batch that generated this block, but could not be included in the block
+	// because the failed basic consensus checks -- invalid signature, nonce too low, etc.
+	//
+	// This field is _not_ normative: it is not included in the block hash and is not considered
+	// part of the L2 chain data. Most block explorers will not show it. This means that the L2
+	// chain still has the exact same data structures and format as an L1 EVM chain. The field is
+	// mainly included here for plumbing: it means that when a batch is executed to produce a block,
+	// information is not lost when transactions from the batch are rejected. Thus, when the block
+	// is converted _back_ to a batch by the batcher, the resulting batch which is sent to the L1
+	// will include all the transactions from the original batch, including the invalid ones.
+	//
+	// Validating OP-nodes which read batches from L1 can then check that the sequencer included all
+	// the transactions it was required to include, if the sequencer was obligated by the Espresso
+	// Sequencer to include certain transactions. Those nodes will then _derive_ the resulting block
+	// by sending the batch to their own engine, which will once again filter out the invalid
+	// transactions, rather than trusting the sequencer about which transactions were invalid.
+	//
+	// Effectively, we have removed the exclusion of invalid transactions as a responsibility of the
+	// sequencer and instead pushed this responsibility into the derivation pipeline/fraud proof
+	// mechanism. As a result, we need this extra field to keep track of the extra information --
+	// invalid transactions -- that is a normative part of a batch but not a block.
+	rejected []RejectedTransaction
+
 	// caches
 	hash atomic.Value
 	size atomic.Value
@@ -188,12 +212,21 @@ type Block struct {
 	ReceivedFrom interface{}
 }
 
+type RejectedTransaction struct {
+	// The raw data of the transaction. This allows us to include even completely malformed data
+	// blobs that were forced into the sequence by end users as rejected transactions.
+	Data []byte
+	// The position in the block at which this tranaction would have appeared had it been valid.
+	Pos int
+}
+
 // "external" block encoding. used for eth protocol, etc.
 type extblock struct {
 	Header      *Header
 	Txs         []*Transaction
 	Uncles      []*Header
-	Withdrawals []*Withdrawal `rlp:"optional"`
+	Withdrawals []*Withdrawal         `rlp:"optional"`
+	Rejected    []RejectedTransaction `rlp:"optional"`
 }
 
 // NewBlock creates a new block. The input data is copied,
@@ -295,7 +328,7 @@ func (b *Block) DecodeRLP(s *rlp.Stream) error {
 	if err := s.Decode(&eb); err != nil {
 		return err
 	}
-	b.header, b.uncles, b.transactions, b.withdrawals = eb.Header, eb.Uncles, eb.Txs, eb.Withdrawals
+	b.header, b.uncles, b.transactions, b.withdrawals, b.rejected = eb.Header, eb.Uncles, eb.Txs, eb.Withdrawals, eb.Rejected
 	b.size.Store(rlp.ListSize(size))
 	return nil
 }
@@ -307,6 +340,7 @@ func (b *Block) EncodeRLP(w io.Writer) error {
 		Txs:         b.transactions,
 		Uncles:      b.uncles,
 		Withdrawals: b.withdrawals,
+		Rejected:    b.rejected,
 	})
 }
 
@@ -351,6 +385,10 @@ func (b *Block) BaseFee() *big.Int {
 
 func (b *Block) Withdrawals() Withdrawals {
 	return b.withdrawals
+}
+
+func (b *Block) Rejected() []RejectedTransaction {
+	return b.rejected
 }
 
 func (b *Block) Header() *Header { return CopyHeader(b.header) }
@@ -423,6 +461,12 @@ func (b *Block) WithWithdrawals(withdrawals []*Withdrawal) *Block {
 		b.withdrawals = make([]*Withdrawal, len(withdrawals))
 		copy(b.withdrawals, withdrawals)
 	}
+	return b
+}
+
+// WithRejected sets the rejected transactions in a block, does not return a new block.
+func (b *Block) WithRejected(rejected []RejectedTransaction) *Block {
+	b.rejected = rejected
 	return b
 }
 

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -358,6 +358,7 @@ func (api *ConsensusAPI) forkchoiceUpdated(update engine.ForkchoiceStateV1, payl
 			Random:       payloadAttributes.Random,
 			Withdrawals:  payloadAttributes.Withdrawals,
 			NoTxPool:     payloadAttributes.NoTxPool,
+			Espresso:     payloadAttributes.Espresso,
 			Transactions: transactions,
 			GasLimit:     payloadAttributes.GasLimit,
 		}

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -42,6 +42,7 @@ type BuildPayloadArgs struct {
 	Withdrawals  types.Withdrawals // The provided withdrawals
 
 	NoTxPool     bool                 // Optimism addition: option to disable tx pool contents from being included
+	Espresso     bool                 // Optimism addition: option to enable Espresso mode
 	Transactions []*types.Transaction // Optimism addition: txs forced into the block via engine API
 	GasLimit     *uint64              // Optimism addition: override gas limit of the block to build
 }
@@ -173,7 +174,7 @@ func (w *worker) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
 	// Build the initial version with no transaction included. It should be fast
 	// enough to run. The empty payload can at least make sure there is something
 	// to deliver for not missing slot.
-	empty, _, err := w.getSealingBlock(args.Parent, args.Timestamp, args.FeeRecipient, args.Random, args.Withdrawals, true, args.Transactions, args.GasLimit)
+	empty, _, err := w.getSealingBlock(args.Parent, args.Timestamp, args.FeeRecipient, args.Random, args.Withdrawals, true, args.Espresso, args.Transactions, args.GasLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +201,7 @@ func (w *worker) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
 			select {
 			case <-timer.C:
 				start := time.Now()
-				block, fees, err := w.getSealingBlock(args.Parent, args.Timestamp, args.FeeRecipient, args.Random, args.Withdrawals, false, args.Transactions, args.GasLimit)
+				block, fees, err := w.getSealingBlock(args.Parent, args.Timestamp, args.FeeRecipient, args.Random, args.Withdrawals, false, false, args.Transactions, args.GasLimit)
 				if err == nil {
 					payload.update(block, fees, time.Since(start))
 				}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1159,7 +1159,7 @@ func (w *worker) generateWork(genParams *generateParams) (*types.Block, *big.Int
 			}
 			rejected = append(rejected, types.RejectedTransaction{
 				Data: bytes,
-				Pos:  len(work.receipts),
+				Pos:  uint64(len(work.receipts)),
 			})
 		} else {
 			work.tcount++

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -632,7 +632,7 @@ func testGetSealingWork(t *testing.T, chainConfig *params.ChainConfig, engine co
 
 	// This API should work even when the automatic sealing is not enabled
 	for _, c := range cases {
-		block, _, err := w.getSealingBlock(c.parent, timestamp, c.coinbase, c.random, nil, false, nil, nil)
+		block, _, err := w.getSealingBlock(c.parent, timestamp, c.coinbase, c.random, nil, false, false, nil, nil)
 		if c.expectErr {
 			if err == nil {
 				t.Error("Expect error but get nil")
@@ -648,7 +648,7 @@ func testGetSealingWork(t *testing.T, chainConfig *params.ChainConfig, engine co
 	// This API should work even when the automatic sealing is enabled
 	w.start()
 	for _, c := range cases {
-		block, _, err := w.getSealingBlock(c.parent, timestamp, c.coinbase, c.random, nil, false, nil, nil)
+		block, _, err := w.getSealingBlock(c.parent, timestamp, c.coinbase, c.random, nil, false, false, nil, nil)
 		if c.expectErr {
 			if err == nil {
 				t.Error("Expect error but get nil")


### PR DESCRIPTION
~~This should only apply to Espresso mode, but making it configurable is quite difficult. For now, in the interest of getting Cortado working as quickly as possible, this change applies to all transactions.~~

This is configurable now. Closes #3 
Closes https://github.com/EspressoSystems/op-espresso-integration/issues/3