### PR TITLE
Add a workflow to build the op-geth Docker image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,48 @@
+name: Build Docker
+on:
+  push:
+    branches:
+      - main
+      - integration
+      - release-*
+    tags:
+      # YYYYMMDD
+      - "20[0-9][0-9][0-1][0-9][0-3][0-9]*"
+  schedule:
+    - cron: "0 0 * * 1"
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Setup Docker BuildKit (buildx)
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Github Container Repo
+        uses: docker/login-action@v2
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate op-geth docker metadata
+        uses: docker/metadata-action@v4
+        id: op-geth
+        with:
+          images: ghcr.io/espressosystems/op-espresso-integration/op-geth
+
+      - name: Build and push op-geth docker
+        uses: docker/build-push-action@v4
+        with:
+          context: ./
+          file: Dockerfile
+          platforms: linux/amd64,arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.op-geth.outputs.tags }}
+          labels: ${{ steps.op-geth.outputs.labels }}


### PR DESCRIPTION
We use a GitHub actions workflow instead of CircleCI to be more consistent with other Espresso Docker images and to avoid having to adapt OP's gcloud-based authentication workflow to work in Espresso Systems GitHub repos.